### PR TITLE
Renamed variables, never use errno als variable name the function was renamed in preprocessor:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.6)
 find_package(Rock)
 rock_init(bfsf 0.1)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+rock_activate_cxx11()
 
 include_directories(include)
 include_directories(interfaces/ff-wrapped)

--- a/external/libff/scan-fct_pddl.y
+++ b/external/libff/scan-fct_pddl.y
@@ -99,7 +99,7 @@ static char * serrmsg[] = {
 };
 
 
-/* void fcterr( int errno, char *par ); */
+void fcterr( int err, char *par ); 
 
 
 static int sact_err;
@@ -874,7 +874,7 @@ NAME  name_star
 
 
 #include "lex.fct_pddl.c"
-
+;
 
 /**********************************************************************
  * Functions
@@ -884,9 +884,9 @@ NAME  name_star
 /* 
  * call	bison -pfct -bscan-fct scan-fct.y
  */
-void fcterr( int errno, char *par ) {
+void fcterr( int err, char *par ) {
 
-/*   sact_err = errno; */
+/*   sact_err = err; */
 
 /*   if ( sact_err_par ) { */
 /*     free( sact_err_par ); */

--- a/external/libff/scan-ops_pddl.y
+++ b/external/libff/scan-ops_pddl.y
@@ -92,7 +92,7 @@ static char *serrmsg[] = {
 };
 
 
-/* void opserr( int errno, char *par ); */
+void opserr( int err, char *par );
 
 
 static int sact_err;
@@ -1002,11 +1002,11 @@ VARIABLE  typed_list_variable        /* a list element (gets type from next one)
  * call	bison -pops -bscan-ops scan-ops.y
  */
 
-void opserr( int errno, char *par )
+void opserr( int err, char *par )
 
 {
 
-/*   sact_err = errno; */
+/*   sact_err = err; */
 
 /*   if ( sact_err_par ) { */
 /*     free(sact_err_par); */


### PR DESCRIPTION
void fcterr( int errno, char *par ) {

to

void fcterr( int (*__errno_location ()), char *par ) {
